### PR TITLE
*Vector* methods provided with comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 2.8.12.2)
 
 project (SharpVector)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -std=c++17 -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -std=c++17 -g -Wno-unknown-pragmas")
 
 set(CMAKE_BINARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Build/Source")
 

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -215,7 +215,7 @@ namespace Cx
         /// Searches for an element that matches the conditions defined by the specified predicate, and returns the first occurrence within the entire Vector
         /// </summary>
         /// <param name="predicate">The std::function delegate that defines the conditions of the element to search for</param>
-        /// <returns></returns>
+        /// <returns>The first element that matches the conditions defined by the specified predicate if found; default T value otherwise</returns>
         T Find( std::function<bool( T )> predicate )
         {
             if( predicate == nullptr )

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -514,7 +514,13 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region InsertRange
+        /// <summary>
+        /// Inserts the elements of a collection into the Vector at the specified index
+        /// </summary>
+        /// <param name="index">The zero-based index at which the new elements should be inserted</param>
+        /// <param name="range">The collection given as pointer to buffer whose elements should be insterted into the Vector</param>
+        /// <param name="n">Number of elements in the collection</param>
         void InsertRange( const unsigned int index, const T* const range, const unsigned int n )
         {
             if( range == nullptr )
@@ -525,6 +531,11 @@ namespace Cx
                 this->insert( this->cbegin() + index + i, range[i] );
         }
 
+        /// <summary>
+        /// Inserts the elements of a collection into the Vector at the specified index
+        /// </summary>
+        /// <param name="index">The zero-based index at which the new elements should be inserted</param>
+        /// <param name="range">The collection whose elements should be inserted into the Vector</param>
         void InsertRange( const unsigned int index, const std::vector<T>& range )
         {
             try
@@ -534,6 +545,11 @@ namespace Cx
             catch( std::invalid_argument& e ) { throw e; }
         }
 
+        /// <summary>
+        /// Inserts the elements of a collection into the Vector at the specified index
+        /// </summary>
+        /// <param name="index">The zero-based index at which the new elements should be inserted</param>
+        /// <param name="range">The collection whose elements should be inserted into the Vector</param>
         void InsertRange( const unsigned int index, std::vector<T>&& range )
         {
             try
@@ -543,6 +559,11 @@ namespace Cx
             catch( std::invalid_argument& e ) { throw e; }
         }
 
+        /// <summary>
+        /// Inserts the elements of a collection into the Vector at the specified index
+        /// </summary>
+        /// <param name="index">The zero-based index at which the new elements should be inserted</param>
+        /// <param name="range">The collection whose elements should be inserted into the Vector</param>
         void InsertRange( const unsigned int index, const Vector<T>& range )
         {
             try
@@ -552,6 +573,11 @@ namespace Cx
             catch( std::invalid_argument& e ) { throw e; }
         }
 
+        /// <summary>
+        /// Inserts the elements of a collection into the Vector at the specified index
+        /// </summary>
+        /// <param name="index">The zero-based index at which the new elements should be inserted</param>
+        /// <param name="range">The collection whose elements should be inserted into the Vector</param>
         void InsertRange( const unsigned int index, Vector<T>&& range )
         {
             try
@@ -560,6 +586,7 @@ namespace Cx
             }
             catch( std::invalid_argument& e ) { throw e; }
         }
+#pragma endregion
 
 
         Vector<T> GetRange( const unsigned int start, const unsigned int end ) const

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -78,6 +78,9 @@ namespace Cx
         }
 
 
+        /// <summary>
+        /// Sorts the elements in the Vector using the default std::sort
+        /// </summary>
         void Sort()
         {
             try
@@ -87,6 +90,11 @@ namespace Cx
             catch( const std::exception& e ) { throw e; }
         }
 
+        /// <summary>
+        /// Sorts a portion of the elements in the Vector using the default std::sort
+        /// </summary>
+        /// <param name="positionBegin">Index of the first element of the portion to sort</param>
+        /// <param name="positionEnd">Index of the last element of the portion to sort</param>
         void Sort( const unsigned int positionBegin, const unsigned int positionEnd )
         {
             Vector<T> vector;
@@ -102,6 +110,10 @@ namespace Cx
             catch( std::exception& e ) { throw e; }
         }
 
+        /// <summary>
+        /// Sorts the elements in the Vector using the specified comparer
+        /// </summary>
+        /// <param name="comparer">Function determining the sort order</param>
         void Sort( std::function<bool( T, T )> comparer )
         {
             try
@@ -111,6 +123,12 @@ namespace Cx
             catch( std::exception& e ) { throw e; }
         }
 
+        /// <summary>
+        /// Sorts a portion of the elements in the Vector using the specified comparer
+        /// </summary>
+        /// <param name="positionBegin">Index of the first element of the portion to sort</param>
+        /// <param name="positionEnd">Index of the last element of the portion to sort</param>
+        /// <param name="comparer">Function determining the sort order</param>
         void Sort( const unsigned int positionBegin, const unsigned int positionEnd, std::function<bool( T, T )> comparer )
         {
             Vector<T> vector;

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -148,11 +148,17 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region Exists
+        /// <summary>
+        /// Determines whether the Vector contains elements that match the conditions defined by the specified predicate
+        /// </summary>
+        /// <param name="predicate">The predicate std::function delegate that defines the conditions of the elements to search for</param>
+        /// <returns>true if the Vector contains one or more elements that match the conditions defined by the specified predicate; false otherwise</returns>
         const bool Exists( std::function<bool( T )> predicate ) const noexcept
         {
             return std::find_if( this->begin(), this->end(), predicate ) != this->end();
         }
+#pragma endregion
 
 
         void CopyTo( const unsigned int index, T* array, const unsigned int arrayIndex, const unsigned int count ) const

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -293,11 +293,18 @@ namespace Cx
         }
 #pragma endregion
 
+#pragma region Remove
+        /// <summary>
+        /// Removes the first occurrence of a specific object from the Vector
+        /// </summary>
+        /// <param name="item">The object to remove from the Vector</param>
+        /// <returns></returns>
         void Remove( T item ) noexcept
         {
             auto it = std::find( this->cbegin(), this->cend(), item );
             this->erase( it );
         }
+#pragma endregion
 
 
         T FindLast( std::function<bool( T )> predicate ) const noexcept

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -210,7 +210,12 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region Find
+        /// <summary>
+        /// Searches for an element that matches the conditions defined by the specified predicate, and returns the first occurrence within the entire Vector
+        /// </summary>
+        /// <param name="predicate">The std::function delegate that defines the conditions of the element to search for</param>
+        /// <returns></returns>
         T Find( std::function<bool( T )> predicate )
         {
             if( predicate == nullptr )
@@ -221,6 +226,7 @@ namespace Cx
                     return it.operator*();
             return T();
         }
+#pragma endregion
 
 
         void RemoveAll( std::function<bool( T )> predicate ) noexcept

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -588,7 +588,13 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region GetRange
+        /// <summary>
+        /// Creates a shallow copy of a range of elements in the source Vector
+        /// </summary>
+        /// <param name="start">The zero-based index in Vector at which the range starts</param>
+        /// <param name="end">The zero-based index in Vector at which the range ends</param>
+        /// <returns>A shallow copy of a range of elements in the source Vector</returns>
         Vector<T> GetRange( const unsigned int start, const unsigned int end ) const
         {
             if( start >= this->size() || end >= this->size() || start >= end )
@@ -598,7 +604,7 @@ namespace Cx
                 newVector.push_back( *it );
             return newVector;
         }
-
+#pragma endregion
 
         const int LastIndexOf( T item ) const noexcept
         {

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -228,11 +228,17 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region RemoveAll
+        /// <summary>
+        /// Removes all the elements that match the conditions defined by the specified predicate
+        /// </summary>
+        /// <param name="predicate">The std::function delegate that defines the conditions of the elements to remove</param>
+        /// <returns></returns>
         void RemoveAll( std::function<bool( T )> predicate ) noexcept
         {
             this->erase( std::remove_if( this->begin(), this->end(), predicate ), this->end() );
         }
+#pragma endregion
 
 
         const bool TrueForAll( std::function<bool( T )> predicate )

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -257,22 +257,41 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region BinarySearch
+        /// <summary>
+        /// Searches the entire sorted Vector for an element using the default comparer and returns the zero-based index of the element
+        /// </summary>
+        /// <param name="item">The object to locate</param>
+        /// <returns>The zero-based index of item in the sorted Vector if item is found; otherwise -1</returns>
         const int BinarySearch( T item ) noexcept
         {
             return BinarySearchGenericImplementation( item, [&]( T element )->bool { return element == item; }, 0, this->size() - 1 );
         }
 
+        /// <summary>
+        /// Searches the entire sorted Vector for an element using the specified comparer
+        /// </summary>
+        /// <param name="item">The object to locate</param>
+        /// <param name="predicate">The std::function predicate to use when comapring elements</param>
+        /// <returns>The zero-based index of item in the sorted Vector if item is found; -1 otherwise</returns>
         const bool BinarySearch( T item, std::function<bool( T )> predicate ) noexcept
         {
             return BinarySearchGenericImplementation( item, predicate, 0, this->size() - 1 );
         }
 
+        /// <summary>
+        /// Searches a range of elements in the sorted Vector for an element using the specified comparer
+        /// </summary>
+        /// <param name="item">The object to locate</param>
+        /// <param name="start">The zero-based starting index of the range to search</param>
+        /// <param name="count">The length of the range to search</param>
+        /// <param name="predicate">The std::function predicate to use when comparing elements</param>
+        /// <returns>The zero-based index of item in the sorted Vector if item is found; -1 otherwise</returns>
         const bool BinarySearch( T item, const unsigned int start, const unsigned int count, std::function<bool( T )> predicate )
         {
             return BinarySearchGenericImplementation( item, predicate, start, count );
         }
-
+#pragma endregion
 
         void Remove( T item ) noexcept
         {

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -683,7 +683,12 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region FindAll
+        /// <summary>
+        /// Retrieve all the elements that match the conditions defined by the specified predicate
+        /// </summary>
+        /// <param name="predicate">The std::function predicate that defines the conditions of the elements to search for</param>
+        /// <returns>A Vector containing all the elements that match the conditions defined by the specified predicate if any is found; empty Vector otherwise</returns>
         Vector<T> FindAll( std::function<bool( T )> predicate ) const noexcept
         {
             Vector<T> results;
@@ -692,7 +697,7 @@ namespace Cx
                     results.push_back( element );
             return results;
         }
-
+#pragma endregion
 
 
     private:

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -657,12 +657,18 @@ namespace Cx
         }
 #pragma endregion
 
+#pragma region RemoveAt
+        /// <summary>
+        /// Removes the element at specified index of the Vector
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to remove</param>
         void RemoveAt( const unsigned int index )
         {
             if( index >= this->size() )
                 throw std::invalid_argument( "index to remove exceeds the container size" );
             this->erase( this->cbegin() + index );
         }
+#pragma endregion
 
 
         void ForEach( std::function<void( T& )> action ) noexcept

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -606,21 +606,40 @@ namespace Cx
         }
 #pragma endregion
 
+#pragma region LastIndexOf
+        /// <summary>
+        /// Searches for the specified object within the entire Vector
+        /// </summary>
+        /// <param name="item">The object to locate in the Vector. The value is not checked against nullptr</param>
+        /// <returns>The zero-based index of the last occurrence of item within the entire Vector if found; -1 otherwise</returns>
         const int LastIndexOf( T item ) const noexcept
         {
             return LastIndexOfGenericImplementation( item, 0, this->size() );
         }
 
+        /// <summary>
+        /// Searches for the specified object within the range of elements in the Vector. The range starts at position index and ends at the last element of Vector
+        /// </summary>
+        /// <param name="item">The object to locate in the Vector. The value is not checked against nullpts</param>
+        /// <param name="index">The zero-based starting index of the range to search</param>
+        /// <returns>The zero-based index of the last occurrence of item within the range of elements in the Vector</returns>
         const int LastIndexOf( T item, const unsigned int index )
         {
             return LastIndexOfGenericImplementation( item, 0, index );
         }
 
+        /// <summary>
+        /// Searches for the specified object within the range of elements in the Vector. The range starts at position index and comprises the number of elements given as count parameter.
+        /// </summary>
+        /// <param name="item">The object to locate in the Vector</param>
+        /// <param name="index">The zero-based starting index of the search</param>
+        /// <param name="count">The number of elements in the search range</param>
+        /// <returns>The zero-based index of the last occurrence within the specified range of elements in the Vector if found; -1 otherwise</returns>
         const int LastIndexOf( T item, const unsigned int index, const unsigned int count )
         {
             return LastIndexOfGenericImplementation( item, index, count );
         }
-
+#pragma endregion
 
         template<class Tout> Vector<Tout> ConvertAll( std::function<Tout( T )> converter ) const noexcept
         {

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -322,13 +322,19 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region RemoveRange
+        /// <summary>
+        /// Removes a range of elements from the Vector
+        /// </summary>
+        /// <param name="start">The zero-based starting index of the range of elements to remove</param>
+        /// <param name="count">The number of elements to remove</param>
         void RemoveRange( const unsigned int start, const unsigned int count )
         {
             if( start + count > this->size() )
                 throw std::invalid_argument( "range exceeds the container size" );
             this->erase( this->cbegin() + start, this->cbegin() + start + count );
         }
+#pragma endregion
 
 
         const int IndexOf( T element ) const

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -240,7 +240,12 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region TrueForAll
+        /// <summary>
+        /// Determines whether every element in the Vector matches the conditions defined by the specified predicate
+        /// </summary>
+        /// <param name="predicate">The std::function delegate that defines the conditions to check whether all elements meets the criteria</param>
+        /// <returns></returns>
         const bool TrueForAll( std::function<bool( T )> predicate )
         {
             if( predicate == nullptr )
@@ -250,6 +255,7 @@ namespace Cx
                     return false;
             return true;
         }
+#pragma endregion
 
 
         const int BinarySearch( T item ) noexcept

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -670,12 +670,18 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region ForEach
+        /// <summary>
+        /// Performes the specified action on each element of the Vector
+        /// </summary>
+        /// <param name="action">The std::function delegate to perform on each element of the Vector</param>
+        /// <returns></returns>
         void ForEach( std::function<void( T& )> action ) noexcept
         {
             for( T& element : *this )
                 action( element );
         }
+#pragma endregion
 
 
         Vector<T> FindAll( std::function<bool( T )> predicate ) const noexcept

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -21,12 +21,22 @@ namespace Cx
         Vector( std::initializer_list<T> initialValues ) noexcept : std::vector<T>( initialValues )
         {}
 
+
+        /// <summary>
+        /// Adds the element of the specified collection to the end of the Vector
+        /// </summary>
+        /// <param name="list">The collection whose elements should be added to the end of the Vector.</param>
         void AddRange( const std::initializer_list<T>& list ) noexcept
         {
             for( auto element : list )
                 this->push_back( element );
         }
 
+        /// <summary>
+        /// Adds the element of the specified collection to the end of the Vector
+        /// </summary>
+        /// <param name="range">The collection whose elements should be added to the end of the Vector.</param>
+        /// <param name="size">Number of elements in the range which should be added</param>
         void AddRange( const T* const range, const unsigned int size ) noexcept
         {
             if( range != nullptr )
@@ -34,12 +44,20 @@ namespace Cx
                     this->push_back( range[i] );
         }
 
+        /// <summary>
+        /// Adds the element of the specified collection to the end of the Vector
+        /// </summary>
+        /// <param name="vector">The collection given as another Vector, whose elements should be copied to the end of current Vector</param>
         void AddRange( const Vector<T>& vector ) noexcept
         {
             for( auto element : vector )
                 this->push_back( element );
         }
 
+        /// <summary>
+        /// Adds the element of the specified collection to the end of the Vector
+        /// </summary>
+        /// <param name="vector">The collection given as another Vector, whose elements should be moved to the end of current Vector</param>
         void AddRange( Vector<T>&& vector ) noexcept
         {
             for( auto element : vector )

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -383,6 +383,12 @@ namespace Cx
         }
 #pragma endregion
 
+#pragma region FindIndex
+        /// <summary>
+        /// Searches for an element that matches the conditions defined by the specified predicate within the entire Vector
+        /// </summary>
+        /// <param name="predicate">The std::function predicate that defines the conditions of the element to search for</param>
+        /// <returns>The zero-based index of the first occurrence of an element that matches the conditions defined by predicate if found; -1 otherwise</returns>
         const int FindIndex( std::function<bool( T )> predicate ) const
         {
             try
@@ -392,6 +398,12 @@ namespace Cx
             catch( const std::invalid_argument& e ) { throw e; }
         }
 
+        /// <summary>
+        /// Searches for an element that matches the conditions defined by the specified predicate within the range of elements in the Vector that extends from the specified index to the last element
+        /// </summary>
+        /// <param name="predicate">The std::function predicate that defines the conditions of the element to search for</param>
+        /// <param name="start">The zero-based starting index of the search</param>
+        /// <returns>The zero-based index of the first occurrence of an element that matches the conditions defined by predicate if found; -1 otherwise</returns>
         const int FindIndex( std::function<bool( T )> predicate, const unsigned int start ) const
         {
             try
@@ -401,6 +413,13 @@ namespace Cx
             catch( const std::invalid_argument& e ) { throw e; }
         }
 
+        /// <summary>
+        /// Searches for an element that matches the conditions defined by the specified predicate within the range of elements in the Vector that starts at the specified index and contains the specified number of elements
+        /// </summary>
+        /// <param name="predicate">The std::function predicate that defines the conditions of the element to search for</param>
+        /// <param name="start">The zero-based starting index of the search</param>
+        /// <param name="count">The number of elements in the section to search</param>
+        /// <returns>The zero-based index of the first occurrence of an element that matches the conditions defined by predicate if found; -1 otherwise</returns>
         const int FindIndex( std::function<bool( T )> predicate, const unsigned int start, const unsigned int count ) const
         {
             try
@@ -409,7 +428,7 @@ namespace Cx
             }
             catch( const std::invalid_argument& e ) { throw e; }
         }
-
+#pragma endregion
 
         void Reverse() noexcept
         {

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -641,6 +641,13 @@ namespace Cx
         }
 #pragma endregion
 
+#pragma region ConvertAll
+        /// <summary>
+        /// Converts the elements in the current Vector to another type and returns a Vector containing the converted elements
+        /// </summary>
+        /// <typeparam name="Tout">The type of the elements of the target array</typeparam>
+        /// <param name="converter">A std::function delegate that converts each element from one type to another type</param>
+        /// <returns>A Vector of the target type containing the converted elements from the current Vector</returns>
         template<class Tout> Vector<Tout> ConvertAll( std::function<Tout( T )> converter ) const noexcept
         {
             Vector<Tout> convertedContainer;
@@ -648,7 +655,7 @@ namespace Cx
                 convertedContainer.push_back( converter( *it ) );
             return convertedContainer;
         }
-
+#pragma endregion
 
         void RemoveAt( const unsigned int index )
         {

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -306,7 +306,12 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region FindLast
+        /// <summary>
+        /// Searches for an element that matches the conditions defined by the specified predicate, and returns the last occurrence within the entire Vector
+        /// </summary>
+        /// <param name="predicate">The std::function delegate that defines the conditions of the element to search for</param>
+        /// <returns>The last element that matches the conditions defined by the specified predicate if found; default T() otherwise</returns>
         T FindLast( std::function<bool( T )> predicate ) const noexcept
         {
             auto resultInstance = T();
@@ -315,6 +320,7 @@ namespace Cx
                     resultInstance = *it;
             return resultInstance;
         }
+#pragma endregion
 
 
         void RemoveRange( const unsigned int start, const unsigned int count )

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -21,7 +21,7 @@ namespace Cx
         Vector( std::initializer_list<T> initialValues ) noexcept : std::vector<T>( initialValues )
         {}
 
-
+#pragma region AddRange
         /// <summary>
         /// Adds the element of the specified collection to the end of the Vector
         /// </summary>
@@ -63,7 +63,9 @@ namespace Cx
             for( auto element : vector )
                 this->push_back( element );
         }
+#pragma endregion
 
+#pragma region Contains
         /// <summary>
         /// Determines whether an element is in the Vector
         /// </summary>
@@ -76,8 +78,9 @@ namespace Cx
                     return true;
             return false;
         }
+#pragma endregion
 
-
+#pragma region Sort
         /// <summary>
         /// Sorts the elements in the Vector using the default std::sort
         /// </summary>
@@ -143,6 +146,7 @@ namespace Cx
             }
             catch( std::exception& e ) { throw e; }
         }
+#pragma endregion
 
 
         const bool Exists( std::function<bool( T )> predicate ) const noexcept

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -456,6 +456,12 @@ namespace Cx
         }
 #pragma endregion
 
+#pragma region FindLastIndex
+        /// <summary>
+        /// Searches for an element that matches the conditions defined by the specified predicate within the entire Vector
+        /// </summary>
+        /// <param name="predicate">The std::function delegate that defines the conditions of the element to search for</param>
+        /// <returns>The zero-based index of the last occurrence of an element that matches the conditions if found; -1 otherwise</returns>
         const int FindLastIndex( std::function<bool( T )> predicate ) const noexcept
         {
             int index = 0;
@@ -466,6 +472,12 @@ namespace Cx
             return lastIndex;
         }
 
+        /// <summary>
+        /// Searches for an element that matches the conditions defined by the specified predicate within the range of elements in the Vector that extends from the first element to the specified index
+        /// </summary>
+        /// <param name="end">The zero-based starting index of the backward search</param>
+        /// <param name="predicate">The std::function delegate that defines the conditions of the element to search for</param>
+        /// <returns>The zero-based index of the last occurrence of an element that matches the conditions if found; -1 otherwise</returns>
         const int FindLastIndex( const unsigned int end, std::function<bool( T )> predicate ) const
         {
             if( end >= this->size() )
@@ -478,6 +490,13 @@ namespace Cx
             return lastIndex;
         }
 
+        /// <summary>
+        /// Searches for an element that matches the conditions defined by the specified predicate within the range of elements in the Vector that contains the specified number of elements and ends at the specified index
+        /// </summary>
+        /// <param name="start">The zero-based starting index of the backward search</param>
+        /// <param name="end">The zero-based ending index of the backward search</param>
+        /// <param name="predicate">The std::function delegate that defines the conditions of the element to search for</param>
+        /// <returns>The zero-based index of the last occurrence of an element that matches the conditions if found; -1 otherwise</returns>
         const int FindLastIndex( const unsigned int start, const unsigned int end, std::function<bool( T )> predicate ) const
         {
             if( start > end )
@@ -493,6 +512,7 @@ namespace Cx
                     lastIndex = index;
             return lastIndex;
         }
+#pragma endregion
 
 
         void InsertRange( const unsigned int index, const T* const range, const unsigned int n )

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -430,6 +430,11 @@ namespace Cx
         }
 #pragma endregion
 
+#pragma region Reverse
+        /// <summary>
+        /// Reverses the order of the elements in the entire Vector
+        /// </summary>
+        /// <returns></returns>
         void Reverse() noexcept
         {
             const auto swapRange = static_cast<int>(this->size() / 2);
@@ -437,6 +442,11 @@ namespace Cx
                 std::swap( this->operator[]( swappedIndex ), this->operator[]( this->size() - 1 - swappedIndex ) );
         }
 
+        /// <summary>
+        /// Reverses the order of the elements in the specified range within the Vector
+        /// </summary>
+        /// <param name="start">The zero-based starting index of the range to reverse</param>
+        /// <param name="count">The number of elements in the range to reverse</param>
         void Reverse( const unsigned int start, const unsigned int count )
         {
             if( start + count >= this->size() )
@@ -444,7 +454,7 @@ namespace Cx
             for( unsigned int swappedIndex = 0; swappedIndex < count / 2; ++swappedIndex )
                 std::swap( this->operator[]( swappedIndex + start ), this->operator[]( start + count - swappedIndex - 1 ) );
         }
-
+#pragma endregion
 
         const int FindLastIndex( std::function<bool( T )> predicate ) const noexcept
         {

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -245,7 +245,7 @@ namespace Cx
         /// Determines whether every element in the Vector matches the conditions defined by the specified predicate
         /// </summary>
         /// <param name="predicate">The std::function delegate that defines the conditions to check whether all elements meets the criteria</param>
-        /// <returns></returns>
+        /// <returns>true if every element in the Vector matches the conditions defined by the predicate; false otherwise</returns>
         const bool TrueForAll( std::function<bool( T )> predicate )
         {
             if( predicate == nullptr )

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -64,7 +64,11 @@ namespace Cx
                 this->push_back( element );
         }
 
-
+        /// <summary>
+        /// Determines whether an element is in the Vector
+        /// </summary>
+        /// <param name="item">The object to locate in the Vector</param>
+        /// <returns>true if item is found in the Vector, false otherwise</returns>
         bool Contains( T item ) const noexcept
         {
             for( auto it = this->begin(); it != this->end(); ++it )

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -336,7 +336,12 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region IndexOf
+        /// <summary>
+        /// Searches for the specified object and returns the zero-based index of the first occurrence within the entire Vector
+        /// </summary>
+        /// <param name="element">The object to locate in the Vector</param>
+        /// <returns>The zero-based index of the first occurrence of item within the entire Vector if found; -1 otherwise</returns>
         const int IndexOf( T element ) const
         {
             try
@@ -346,6 +351,12 @@ namespace Cx
             catch( const std::invalid_argument& e ) { throw e; }
         }
 
+        /// <summary>
+        /// Searches for the specified object and returns the zero-based index of the first occurrence within the range of elements in the Vector that extends from the specified index to the last element
+        /// </summary>
+        /// <param name="element">The object to locate in the Vector</param>
+        /// <param name="start">The zero-based starting index of the search</param>
+        /// <returns>The zero-based index of the first occurrence of item within the entire Vector if found; -1 otherwise</returns>
         const int IndexOf( T element, const unsigned int start ) const
         {
             try
@@ -355,6 +366,13 @@ namespace Cx
             catch( const std::invalid_argument& e ) { throw e; }
         }
 
+        /// <summary>
+        /// Searches for the specified object and returns the zero-based index of the first occurrence within the range of elements in the Vector that starts at the specified index and contains the specified number of elements
+        /// </summary>
+        /// <param name="element">The object to locate in the specified range within the Vector</param>
+        /// <param name="start">The zero-based starting index of the search</param>
+        /// <param name="count">The number of elements in the section to search</param>
+        /// <returns>The zero-based index of the first occurrence of item within the entire Vector if found; -1 otherwise</returns>
         const int IndexOf( T element, const unsigned int start, const unsigned int count ) const
         {
             try
@@ -363,7 +381,7 @@ namespace Cx
             }
             catch( const std::invalid_argument& e ) { throw e; }
         }
-
+#pragma endregion
 
         const int FindIndex( std::function<bool( T )> predicate ) const
         {

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -160,7 +160,14 @@ namespace Cx
         }
 #pragma endregion
 
-
+#pragma region CopyTo
+        /// <summary>
+        /// Copies a range of elements from the Vector to a compatible one-dimensional array starting at the specified index of the target
+        /// </summary>
+        /// <param name="index">The zero-based index in the source Vector at which copying begins</param>
+        /// <param name="array">The one-dimensional array that is the destination of the elements copied from from Vector. The array must have zero-based indexing</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins</param>
+        /// <param name="count">The number of elements to copy</param>
         void CopyTo( const unsigned int index, T* array, const unsigned int arrayIndex, const unsigned int count ) const
         {
             if( array == nullptr )
@@ -171,6 +178,11 @@ namespace Cx
                 array[arrayIndex + copiedElements] = this->operator[]( index + copiedElements );
         }
 
+        /// <summary>
+        /// Copies the entire Vector to a compatible one-dimensional array, starting at the beginning of the target array
+        /// </summary>
+        /// <param name="array">The one-dimensional array that is the destination of the elements copied from Vector</param>
+        /// <param name="size">Size of target array which the Vector's elements are copied to</param>
         void CopyTo( T* array, const unsigned int size )
         {
             if( array == nullptr )
@@ -181,6 +193,12 @@ namespace Cx
                 array[i] = this->at( i );
         }
 
+        /// <summary>
+        /// Copies the entire Vector to a compatible one-dimensional array, starting at the specified index of the target array
+        /// </summary>
+        /// <param name="array">The one-dimensional array that is the destination of the elements copied from Vector</param>
+        /// <param name="size">Size of target array which the Vector's elements are copied to</param>
+        /// <param name="arrayIndex">The zero-based index in the array at which copying begins</param>
         void CopyTo( T* array, const unsigned int size, unsigned int arrayIndex )
         {
             if( array == nullptr )
@@ -190,6 +208,7 @@ namespace Cx
             for( unsigned int i = 0; i < this->size(); ++i, ++arrayIndex )
                 array[arrayIndex] = this->at( i );
         }
+#pragma endregion
 
 
         T Find( std::function<bool( T )> predicate )


### PR DESCRIPTION
This pull request fixes #9 

It delivers the comments of each **public** method of *Vector* source code method.

---

The comments are implemented using the doxygen format, which allows the comments to be displayed as embedded in Visual Studio (are other IDE's supported with such option?).
Each comment applies to each method, also the overloads are covered with custom comment.

Most comments are similar to those used for *List<T>* [methods](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1?view=net-5.0#methods), but as the implementation of C++ has some differences which were applied to the *SharpVector*, it was necessary to adjust the comments.

---

**Why public only?**
The private methods of SharpVector project should not be used, as they are to be used by the whole source code. They are however available in the codebase which is to be downloaded when use, but avoiding commenting the private methods is to discourage to use them independently.

