### PR TITLE
Fix: Remove unused includes from the `Vector` source

### DIFF
--- a/.github/packaging/README.txt
+++ b/.github/packaging/README.txt
@@ -28,7 +28,7 @@ To use this tool:
 
 **NOTE:**
 SharpVector already uses several other includes from standard library, such as the following:
-*memory*, *vector*, *iostream*, *algorithm*, *functional*, *string*, *exception*
+*vector*, *iostream*, *algorithm*, *functional*
 
 ---
 

--- a/Examples/Examples/BusinessObject.cpp
+++ b/Examples/Examples/BusinessObject.cpp
@@ -1,5 +1,6 @@
 #include "../ErrorCodes.hpp"
 #include "../../Source/Vector.hpp"
+#include <string>
 
 
 namespace Examples

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To use this tool:
 
 **NOTE:**
 <br/>SharpVector already uses several other includes from standard library, such as the following:
-<br/>*memory*, *vector*, *iostream*, *algorithm*, *functional*, *string*, *exception*
+<br/>*vector*, *iostream*, *algorithm*, *functional*
 
 ---
 

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <iostream>
 #include <algorithm>
 #include <functional>
-#include <string>
-#include <exception>
 
 
 namespace Cx


### PR DESCRIPTION
This pull request fixes #15 

It removes all the unnecessary includes from the main source of the SharpVector project.

---

Eventually the list of includes was changed from:
*memory*, *vector*, *iostream*, *algorithm*, *functional*, *string*, *exception*
to
~*memory*~, *vector*, *iostream*, *algorithm*, *functional*, ~*string*~, ~*exception*~

Also the README has been updated accordingly to this change.