### PR TITLE
Fix: `CopyTo` provided with other types overloads

### DIFF
--- a/.github/packaging/README.txt
+++ b/.github/packaging/README.txt
@@ -28,7 +28,7 @@ To use this tool:
 
 **NOTE:**
 ExtendedVector already uses several other includes from standard library, such as the following:
-*vector*, *iostream*, *algorithm*, *functional*
+*vector*, *iostream*, *algorithm*, *functional*, *array*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To use this tool:
 
 **NOTE:**
 <br/>ExtendedVector already uses several other includes from standard library, such as the following:
-<br/>*vector*, *iostream*, *algorithm*, *functional*
+<br/>*vector*, *iostream*, *algorithm*, *functional*, *array*
 
 ---
 

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <algorithm>
 #include <functional>
+#include <array>
 
 
 namespace Cx
@@ -240,6 +241,45 @@ namespace Cx
         {
             for( unsigned int i = 0; i < this->size(); ++i )
                 array.insert( array.cbegin() + i + arrayIndex, this->at( i ) );
+        }
+
+        /// <summary>
+        /// Copies a range of elements from the Vector to a compatible one-dimensional array starting at the specified index of the target
+        /// </summary>
+        /// <param name="index">The zero-based index in the source Vector at which copying begins</param>
+        /// <param name="array">The destination std::vector where the elements are copied to from Vector.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins</param>
+        /// <param name="count">The number of elements to copy</param>
+        template<std::size_t size>
+        void CopyTo( const unsigned int index, std::array<T, size>& array, const unsigned int arrayIndex, const unsigned int count )
+        {
+            if( index >= this->size() || arrayIndex >= array.size() )
+                throw std::out_of_range( "index exceeds the size of Vector" );
+            for( unsigned int copiedElements = 0; copiedElements < count; ++copiedElements )
+                array[copiedElements + arrayIndex] = this->operator[]( index + copiedElements );
+        }
+
+        /// <summary>
+        /// Copies the entire Vector to a compatible std::vector, starting at the beginning of the target array
+        /// </summary>
+        /// <param name="array">The std::vector that is the destination of the elements copied from Vector</param>
+        template<std::size_t size>
+        void CopyTo( std::array<T, size>& array )
+        {
+            for( unsigned int i = 0; i < this->size(); ++i )
+                array[i] = this->at( i );
+        }
+
+        /// <summary>
+        /// Copies the entire Vector to a compatible std::vector, starting at the specified index of the target array
+        /// </summary>
+        /// <param name="array">The std::vector that is the destination of the elements copied from Vector</param>
+        /// <param name="arrayIndex">The zero-based index in the array at which copying begins</param>
+        template<std::size_t size>
+        void CopyTo( std::array<T, size>& array, unsigned int arrayIndex )
+        {
+            for( unsigned int i = 0; i < this->size(); ++i )
+                array[i + arrayIndex] = this->at( i );
         }
 #pragma endregion
 

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -205,6 +205,42 @@ namespace Cx
             for( unsigned int i = 0; i < this->size(); ++i, ++arrayIndex )
                 array[arrayIndex] = this->at( i );
         }
+
+        /// <summary>
+        /// Copies a range of elements from the Vector to a compatible one-dimensional array starting at the specified index of the target
+        /// </summary>
+        /// <param name="index">The zero-based index in the source Vector at which copying begins</param>
+        /// <param name="array">The destination std::vector where the elements are copied to from Vector.</param>
+        /// <param name="arrayIndex">The zero-based index in array at which copying begins</param>
+        /// <param name="count">The number of elements to copy</param>
+        void CopyTo( const unsigned int index, std::vector<T>& array, const unsigned int arrayIndex, const unsigned int count )
+        {
+            if( index >= this->size() || arrayIndex >= array.size() )
+                throw std::out_of_range( "index exceeds the size of Vector" );
+            for( unsigned int copiedElements = 0; copiedElements < count; ++copiedElements )
+                array.insert( array.cbegin() + copiedElements + arrayIndex, this->operator[]( index + copiedElements ) );
+        }
+
+        /// <summary>
+        /// Copies the entire Vector to a compatible std::vector, starting at the beginning of the target array
+        /// </summary>
+        /// <param name="array">The std::vector that is the destination of the elements copied from Vector</param>
+        void CopyTo( std::vector<T>& array )
+        {
+            for( unsigned int i = 0; i < this->size(); ++i )
+                array.insert( array.cbegin() + i, this->at( i ) );
+        }
+
+        /// <summary>
+        /// Copies the entire Vector to a compatible std::vector, starting at the specified index of the target array
+        /// </summary>
+        /// <param name="array">The std::vector that is the destination of the elements copied from Vector</param>
+        /// <param name="arrayIndex">The zero-based index in the array at which copying begins</param>
+        void CopyTo( std::vector<T>& array, unsigned int arrayIndex )
+        {
+            for( unsigned int i = 0; i < this->size(); ++i )
+                array.insert( array.cbegin() + i + arrayIndex, this->at( i ) );
+        }
 #pragma endregion
 
 #pragma region Find

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -247,7 +247,7 @@ namespace Cx
         /// Copies a range of elements from the Vector to a compatible one-dimensional array starting at the specified index of the target
         /// </summary>
         /// <param name="index">The zero-based index in the source Vector at which copying begins</param>
-        /// <param name="array">The destination std::vector where the elements are copied to from Vector.</param>
+        /// <param name="array">The destination std::array where the elements are copied to from Vector.</param>
         /// <param name="arrayIndex">The zero-based index in array at which copying begins</param>
         /// <param name="count">The number of elements to copy</param>
         template<std::size_t size>
@@ -260,9 +260,9 @@ namespace Cx
         }
 
         /// <summary>
-        /// Copies the entire Vector to a compatible std::vector, starting at the beginning of the target array
+        /// Copies the entire Vector to a compatible std::array, starting at the beginning of the target array
         /// </summary>
-        /// <param name="array">The std::vector that is the destination of the elements copied from Vector</param>
+        /// <param name="array">The std::array that is the destination of the elements copied from Vector</param>
         template<std::size_t size>
         void CopyTo( std::array<T, size>& array )
         {
@@ -271,9 +271,9 @@ namespace Cx
         }
 
         /// <summary>
-        /// Copies the entire Vector to a compatible std::vector, starting at the specified index of the target array
+        /// Copies the entire Vector to a compatible std::array, starting at the specified index of the target array
         /// </summary>
-        /// <param name="array">The std::vector that is the destination of the elements copied from Vector</param>
+        /// <param name="array">The std::array that is the destination of the elements copied from Vector</param>
         /// <param name="arrayIndex">The zero-based index in the array at which copying begins</param>
         template<std::size_t size>
         void CopyTo( std::array<T, size>& array, unsigned int arrayIndex )

--- a/Tests/VectorTests.cpp
+++ b/Tests/VectorTests.cpp
@@ -1,5 +1,6 @@
 #include "CppUnitTest.h"
 #include "Vector.hpp"
+#include <array>
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -221,7 +222,7 @@ namespace Cx
         }
 
 
-        TEST_METHOD( CopyToWithCustomStartingIndexesOfBothArrays )
+        TEST_METHOD( CopyToArrayPointerWithCustomStartingIndexesOfBothArrays )
         {
             vector.AddRange( { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19 } );
             int destinationArray[10] = { 0,1,2,3,4,5 };
@@ -231,7 +232,7 @@ namespace Cx
             Assert::IsTrue( destinationArray[9] == 13 );
         }
 
-        TEST_METHOD( CopyToAllElements )
+        TEST_METHOD( CopyToArrayPointerAllElements )
         {
             vector.AddRange( { 10,11,12,13,14,15,16,17,18,19 } );
             int destinationArray[10] = { 0,1,2,3,4,5 };
@@ -242,10 +243,74 @@ namespace Cx
             Assert::IsTrue( destinationArray[8] == 18 );
         }
 
-        TEST_METHOD( CopyToAllElementsWithCustomStartingIndex )
+        TEST_METHOD( CopyToArrayPointerAllElementsWithCustomStartingIndex )
         {
             vector.AddRange( { 6,7,8,9 } );
             int destinationArray[10] = { 0,1,2,3,4,5 };
+            vector.CopyTo( destinationArray, 10, 6 );
+            Assert::IsTrue( destinationArray[0] == 0 );
+            Assert::IsTrue( destinationArray[6] == 6 );
+            Assert::IsTrue( destinationArray[7] == 7 );
+            Assert::IsTrue( destinationArray[8] == 8 );
+        }
+
+        TEST_METHOD( CopyToVectorWithCustomStartingIndexesOfBothArrays )
+        {
+            vector.AddRange( { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19 } );
+            std::vector<int> destinationArray = { 0,1,2,3,4,5 };
+            vector.CopyTo( 11, destinationArray, 7, 3 );
+            Assert::IsTrue( destinationArray[7] == 11 );
+            Assert::IsTrue( destinationArray[8] == 12 );
+            Assert::IsTrue( destinationArray[9] == 13 );
+        }
+
+        TEST_METHOD( CopyToVectorAllElements )
+        {
+            vector.AddRange( { 10,11,12,13,14,15,16,17,18,19 } );
+            std::vector<int> destinationArray = { 0,1,2,3,4,5 };
+            vector.CopyTo( destinationArray, 10 );
+            Assert::IsTrue( destinationArray[0] == 10 );
+            Assert::IsTrue( destinationArray[6] == 16 );
+            Assert::IsTrue( destinationArray[7] == 17 );
+            Assert::IsTrue( destinationArray[8] == 18 );
+        }
+
+        TEST_METHOD( CopyToVectorAllElementsWithCustomStartingIndex )
+        {
+            vector.AddRange( { 6,7,8,9 } );
+            std::vector<int> destinationArray = { 0,1,2,3,4,5 };
+            vector.CopyTo( destinationArray, 10, 6 );
+            Assert::IsTrue( destinationArray[0] == 0 );
+            Assert::IsTrue( destinationArray[6] == 6 );
+            Assert::IsTrue( destinationArray[7] == 7 );
+            Assert::IsTrue( destinationArray[8] == 8 );
+        }
+
+        TEST_METHOD( CopyToArrayWithCustomStartingIndexesOfBothArrays )
+        {
+            vector.AddRange( { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19 } );
+            std::array<int, 10> destinationArray = { 0,1,2,3,4,5 };
+            vector.CopyTo( 11, destinationArray, 7, 3 );
+            Assert::IsTrue( destinationArray[7] == 11 );
+            Assert::IsTrue( destinationArray[8] == 12 );
+            Assert::IsTrue( destinationArray[9] == 13 );
+        }
+
+        TEST_METHOD( CopyToArrayAllElements )
+        {
+            vector.AddRange( { 10,11,12,13,14,15,16,17,18,19 } );
+            std::array<int, 10> destinationArray = { 0,1,2,3,4,5 };
+            vector.CopyTo( destinationArray, 10 );
+            Assert::IsTrue( destinationArray[0] == 10 );
+            Assert::IsTrue( destinationArray[6] == 16 );
+            Assert::IsTrue( destinationArray[7] == 17 );
+            Assert::IsTrue( destinationArray[8] == 18 );
+        }
+
+        TEST_METHOD( CopyToArrayAllElementsWithCustomStartingIndex )
+        {
+            vector.AddRange( { 6,7,8,9 } );
+            std::array<int, 10> destinationArray = { 0,1,2,3,4,5 };
             vector.CopyTo( destinationArray, 10, 6 );
             Assert::IsTrue( destinationArray[0] == 0 );
             Assert::IsTrue( destinationArray[6] == 6 );

--- a/Tests/VectorTests.cpp
+++ b/Tests/VectorTests.cpp
@@ -325,6 +325,45 @@ namespace Cx
             Assert::IsTrue( destinationArray[8] == 8 );
         }
 
+        TEST_METHOD( CopyToThisVectorWithCustomStartingIndexesOfBothArrays )
+        {
+            vector.AddRange( { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 } );
+            Vector<int> destinationArray = { 0, 1, 2, 3, 4, 5 };
+            vector.CopyTo( 11, destinationArray, 3, 3 );
+            Assert::IsTrue( destinationArray[3] == 11 );
+            Assert::IsTrue( destinationArray[4] == 12 );
+            Assert::IsTrue( destinationArray[5] == 13 );
+            Assert::IsTrue( destinationArray[6] == 3 );
+            Assert::IsTrue( destinationArray[7] == 4 );
+            Assert::IsTrue( destinationArray[8] == 5 );
+        }
+
+        TEST_METHOD( CopyToThisVectorAllElements )
+        {
+            vector.AddRange( { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 } );
+            Vector<int> destinationArray = { 0, 1, 2, 3, 4, 5 };
+            vector.CopyTo( destinationArray );
+            Assert::IsTrue( destinationArray[0] == 10 );
+            Assert::IsTrue( destinationArray[6] == 16 );
+            Assert::IsTrue( destinationArray[7] == 17 );
+            Assert::IsTrue( destinationArray[8] == 18 );
+            Assert::IsTrue( destinationArray[10] == 0 );
+            Assert::IsTrue( destinationArray[11] == 1 );
+        }
+
+        TEST_METHOD( CopyToThisVectorAllElementsWithCustomStartingIndex )
+        {
+            vector.AddRange( { 6, 7, 8, 9 } );
+            Vector<int> destinationArray = { 0, 1, 2, 3, 4, 5 };
+            vector.CopyTo( destinationArray, 4 );
+            Assert::IsTrue( destinationArray[0] == 0 );
+            Assert::IsTrue( destinationArray[3] == 3 );
+            Assert::IsTrue( destinationArray[4] == 6 );
+            Assert::IsTrue( destinationArray[6] == 8 );
+            Assert::IsTrue( destinationArray[7] == 9 );
+            Assert::IsTrue( destinationArray[8] == 4 );
+        }
+
 
         TEST_METHOD( FindBasicTypeElement )
         {

--- a/Tests/VectorTests.cpp
+++ b/Tests/VectorTests.cpp
@@ -258,32 +258,39 @@ namespace Cx
         {
             vector.AddRange( { 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19 } );
             std::vector<int> destinationArray = { 0,1,2,3,4,5 };
-            vector.CopyTo( 11, destinationArray, 7, 3 );
-            Assert::IsTrue( destinationArray[7] == 11 );
-            Assert::IsTrue( destinationArray[8] == 12 );
-            Assert::IsTrue( destinationArray[9] == 13 );
+            vector.CopyTo( 11, destinationArray, 3, 3 );
+            Assert::IsTrue( destinationArray[3] == 11 );
+            Assert::IsTrue( destinationArray[4] == 12 );
+            Assert::IsTrue( destinationArray[5] == 13 );
+            Assert::IsTrue( destinationArray[6] == 3 );
+            Assert::IsTrue( destinationArray[7] == 4 );
+            Assert::IsTrue( destinationArray[8] == 5 );
         }
 
         TEST_METHOD( CopyToVectorAllElements )
         {
             vector.AddRange( { 10,11,12,13,14,15,16,17,18,19 } );
             std::vector<int> destinationArray = { 0,1,2,3,4,5 };
-            vector.CopyTo( destinationArray, 10 );
+            vector.CopyTo( destinationArray );
             Assert::IsTrue( destinationArray[0] == 10 );
             Assert::IsTrue( destinationArray[6] == 16 );
             Assert::IsTrue( destinationArray[7] == 17 );
             Assert::IsTrue( destinationArray[8] == 18 );
+            Assert::IsTrue( destinationArray[10] == 0 );
+            Assert::IsTrue( destinationArray[11] == 1 );
         }
 
         TEST_METHOD( CopyToVectorAllElementsWithCustomStartingIndex )
         {
             vector.AddRange( { 6,7,8,9 } );
             std::vector<int> destinationArray = { 0,1,2,3,4,5 };
-            vector.CopyTo( destinationArray, 10, 6 );
+            vector.CopyTo( destinationArray, 4 );
             Assert::IsTrue( destinationArray[0] == 0 );
-            Assert::IsTrue( destinationArray[6] == 6 );
-            Assert::IsTrue( destinationArray[7] == 7 );
-            Assert::IsTrue( destinationArray[8] == 8 );
+            Assert::IsTrue( destinationArray[3] == 3 );
+            Assert::IsTrue( destinationArray[4] == 6 );
+            Assert::IsTrue( destinationArray[6] == 8 );
+            Assert::IsTrue( destinationArray[7] == 9 );
+            Assert::IsTrue( destinationArray[8] == 4 );
         }
 
         TEST_METHOD( CopyToArrayWithCustomStartingIndexesOfBothArrays )

--- a/Tests/VectorTests.cpp
+++ b/Tests/VectorTests.cpp
@@ -307,7 +307,7 @@ namespace Cx
         {
             vector.AddRange( { 10,11,12,13,14,15,16,17,18,19 } );
             std::array<int, 10> destinationArray = { 0,1,2,3,4,5 };
-            vector.CopyTo( destinationArray, 10 );
+            vector.CopyTo( destinationArray );
             Assert::IsTrue( destinationArray[0] == 10 );
             Assert::IsTrue( destinationArray[6] == 16 );
             Assert::IsTrue( destinationArray[7] == 17 );
@@ -318,7 +318,7 @@ namespace Cx
         {
             vector.AddRange( { 6,7,8,9 } );
             std::array<int, 10> destinationArray = { 0,1,2,3,4,5 };
-            vector.CopyTo( destinationArray, 10, 6 );
+            vector.CopyTo( destinationArray, 6 );
             Assert::IsTrue( destinationArray[0] == 0 );
             Assert::IsTrue( destinationArray[6] == 6 );
             Assert::IsTrue( destinationArray[7] == 7 );


### PR DESCRIPTION
This pull request fixes #11 

It provides the `CopyTo()` method with additional container types overloads such as: `std::array` and `std::vector`

---

The implementation is very basic:
It overloads and adapts the original raw pointer oriented overload and uses the given type under the hood.

Unit tests checks the same scenarios as for the raw pointer method, but in addition they are extended with correct insertion cases, where part of original sequence is moved by given offset.

This pull request also adjusts the README documentation regarding the dependencies - *array* header had to be included so the `std::array` can be supported.
