### PR TITLE
Capacity constructor for the `Cx::Vector`

### DIFF
--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -13,11 +13,24 @@ namespace Cx
     class Vector : public std::vector<T>
     {
     public:
+#pragma region Constructors
         Vector() noexcept : std::vector<T>()
         {}
 
         Vector( std::initializer_list<T> initialValues ) noexcept : std::vector<T>( initialValues )
         {}
+
+        /// <summary>
+        /// Initializes a new instance of the Vector class that is empty and has the specified initial capacity.
+        /// </summary>
+        /// <param name="capacity">The number of elements that the new vector can initially store</param>
+        /// <returns></returns>
+        Vector( const int capacity ) : std::vector<T>( capacity )
+        {
+            if( capacity < 0 )
+                throw std::invalid_argument( "capacity cannot be lower than 0" );
+        }
+#pragma endregion
 
 #pragma region AddRange
         /// <summary>

--- a/Tests/VectorTests.cpp
+++ b/Tests/VectorTests.cpp
@@ -33,8 +33,22 @@ namespace Cx
         };
 
     public:
-		
-		TEST_METHOD( AddRangeByInitializerListTest )
+
+        TEST_METHOD( ConstructVectorByCapacity )
+        {
+            const size_t correctCapacity = 10;
+            auto capacityVec = Cx::Vector<int>( correctCapacity );
+            Assert::IsTrue( capacityVec.capacity() == correctCapacity );
+        }
+
+        TEST_METHOD( CapacityConstructorThrowsWhenNegativeCapacity )
+        {
+            const int negativeCapacity = -10;
+            Assert::ExpectException<std::exception>( [=]()->void { auto vec = Cx::Vector<int>( negativeCapacity ); } );
+        }
+
+
+        TEST_METHOD( AddRangeByInitializerListTest )
         {
             vector.AddRange( { 1,4,12,8 } );
             Assert::IsTrue( vector[0] == 1 );


### PR DESCRIPTION
This pull request provides the `Cx::Vector` with the capacity constructor, the same as for the .NET [List<T>(Int32)](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.-ctor?view=netframework-4.8#System_Collections_Generic_List_1__ctor_System_Int32_) constructor.

It also implements all the required unit tests which checks both the successfull and unsuccessfull scenario of creating the Vector.