### PR TITLE
License header in Vector.hpp Source & all other files

### DIFF
--- a/Examples/ErrorCodes.hpp
+++ b/Examples/ErrorCodes.hpp
@@ -1,3 +1,6 @@
+// Copyright (c) Cx Code - Bartosz Klonowski.
+// Licensed under the MIT License.
+
 #pragma once
 
 enum class ErrorCodes

--- a/Examples/Examples/BusinessObject.cpp
+++ b/Examples/Examples/BusinessObject.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Cx Code - Bartosz Klonowski.
+// Licensed under the MIT License.
+
 #include "../ErrorCodes.hpp"
 #include "../../Source/Vector.hpp"
 #include <string>

--- a/Examples/Examples/CitiesFilteringApplication.cpp
+++ b/Examples/Examples/CitiesFilteringApplication.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Cx Code - Bartosz Klonowski.
+// Licensed under the MIT License.
+
 #include "../ErrorCodes.hpp"
 #include "../../Source/Vector.hpp"
 #include <string>

--- a/Examples/Examples/Coordinates.cpp
+++ b/Examples/Examples/Coordinates.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Cx Code - Bartosz Klonowski.
+// Licensed under the MIT License.
+
 #include "../ErrorCodes.hpp"
 #include "../../Source/Vector.hpp"
 

--- a/Examples/Source.cpp
+++ b/Examples/Source.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Cx Code - Bartosz Klonowski.
+// Licensed under the MIT License.
+
 #include <iostream>
 
 #include "Examples/CitiesFilteringApplication.cpp"

--- a/Source/Vector.cpp
+++ b/Source/Vector.cpp
@@ -1,1 +1,4 @@
+// Copyright (c) Cx Code - Bartosz Klonowski.
+// Licensed under the MIT License.
+
 #include "Vector.hpp"

--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -1,3 +1,6 @@
+// Copyright (c) Cx Code - Bartosz Klonowski.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <vector>

--- a/Tests/VectorTests.cpp
+++ b/Tests/VectorTests.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Cx Code - Bartosz Klonowski.
+// Licensed under the MIT License.
+
 #include "CppUnitTest.h"
 #include "Vector.hpp"
 #include <array>


### PR DESCRIPTION
This pull request fixes #26 

It delivers the shortened license header to all the source code files in the *ExtendedVector* project.

---

The license header (added as a comment at the top of each source code file) is shortened so it's still easier to read the file but the license information is kept and available.
Although only the *Vector.hpp* source file is packed during the release procedure, all files were provided with the license header.
For the reason why please check the commit messages.
