### PR TITLE
Support `std::array<>` for `AddRange` method

### DIFF
--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -77,6 +77,28 @@ namespace Cx
             for( auto element : vector )
                 this->push_back( element );
         }
+
+        /// <summary>
+        /// Adds all elements of the specified collection to the end of the Vector
+        /// </summary>
+        /// <param name="range">The collection given as std::array, whose elements should be moved to the end of current Vector</param>
+        template<std::size_t size>
+        void AddRange( const std::array<T, size>& range ) noexcept
+        {
+            for( auto element : range )
+                this->push_back( element );
+        }
+
+        /// <summary>
+        /// Adds all elements of the specified collection to the end of the Vector
+        /// </summary>
+        /// <param name="range">The collection given as std::array, whose elements should be moved to the end of current Vector</param>
+        template<std::size_t size>
+        void AddRange( std::array<T, size>&& range ) noexcept
+        {
+            for( auto element : range )
+                this->push_back( element );
+        }
 #pragma endregion
 
 #pragma region Contains

--- a/Tests/VectorTests.cpp
+++ b/Tests/VectorTests.cpp
@@ -95,6 +95,25 @@ namespace Cx
             Assert::IsTrue( vector[3] == 56 );
         }
 
+        TEST_METHOD( AddRangeByStandardArrayGivenByReference )
+        {
+            std::array<int, 4> range( { 1, 15, 23, 56 } );
+            vector.AddRange( std::move( range ) );
+            Assert::IsTrue( vector[0] == 1 );
+            Assert::IsTrue( vector[1] == 15 );
+            Assert::IsTrue( vector[2] == 23 );
+            Assert::IsTrue( vector[3] == 56 );
+        }
+
+        TEST_METHOD( AddRangeByStandardArrayGivenByRValue )
+        {
+            std::array<int, 4> range( { 1, 15, 23, 56 } );
+            vector.AddRange( std::move( range ) );
+            Assert::IsTrue( vector[0] == 1 );
+            Assert::IsTrue( vector[1] == 15 );
+            Assert::IsTrue( vector[2] == 23 );
+            Assert::IsTrue( vector[3] == 56 );
+        }
 
         TEST_METHOD( ContainerWithBasicTypesContainsAnElement )
         {


### PR DESCRIPTION
This pull request adds the `std::array<>` support to the `AddRange` method implementation.
This container is supported for both lvalue and rvalue types given as an argument.

**NOTE:** There is a rule of keeping all `<summary>` descriptions the same across all overloads of one method, but the `AddRange` has a (at least) typo in its description.