### PR TITLE
Fix: `AddRange` method comment singular -> plural

### DIFF
--- a/Source/Vector.hpp
+++ b/Source/Vector.hpp
@@ -37,7 +37,7 @@ namespace Cx
 
 #pragma region AddRange
         /// <summary>
-        /// Adds the element of the specified collection to the end of the Vector
+        /// Adds all elements of the specified collection to the end of the Vector
         /// </summary>
         /// <param name="list">The collection whose elements should be added to the end of the Vector.</param>
         void AddRange( const std::initializer_list<T>& list ) noexcept
@@ -47,7 +47,7 @@ namespace Cx
         }
 
         /// <summary>
-        /// Adds the element of the specified collection to the end of the Vector
+        /// Adds all elements of the specified collection to the end of the Vector
         /// </summary>
         /// <param name="range">The collection whose elements should be added to the end of the Vector.</param>
         /// <param name="size">Number of elements in the range which should be added</param>
@@ -59,7 +59,7 @@ namespace Cx
         }
 
         /// <summary>
-        /// Adds the element of the specified collection to the end of the Vector
+        /// Adds all elements of the specified collection to the end of the Vector
         /// </summary>
         /// <param name="vector">The collection given as another Vector, whose elements should be copied to the end of current Vector</param>
         void AddRange( const Vector<T>& vector ) noexcept
@@ -69,7 +69,7 @@ namespace Cx
         }
 
         /// <summary>
-        /// Adds the element of the specified collection to the end of the Vector
+        /// Adds all elementa of the specified collection to the end of the Vector
         /// </summary>
         /// <param name="vector">The collection given as another Vector, whose elements should be moved to the end of current Vector</param>
         void AddRange( Vector<T>&& vector ) noexcept


### PR DESCRIPTION
This pull request fixes a minor issue with `AddRange` description, which had a mistake of singular form of element.
This is now changed to plural form for all overloads which are affected.